### PR TITLE
int32 -> int

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 func main() {
-	var balance int32 = 15_000_000_00 // 15 миллионов в копейках
-	var transfer int32 = 10_000_000_00 // 10 миллионов в копейках
-	total := balance + transfer // int32 + int32 будет int32
+	var balance = 15_000_000_00  // 15 миллионов в копейках
+	var transfer = 10_000_000_00 // 10 миллионов в копейках
+	total := balance + transfer  // int32 + int32 будет int32
 	println(total)
 }


### PR DESCRIPTION
Для решения проблемы переполнения типа, убрал указание конкретной размерности int`а. Так будет использоваться дефолтный тип int которого будет хватать для хранения результата вычислений.